### PR TITLE
fixed SHC aborting when it receives a joint state message with joints it isn't controlling

### DIFF
--- a/src/state_controller.cpp
+++ b/src/state_controller.cpp
@@ -125,7 +125,7 @@ StateController::~StateController(void)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void StateController::init(void)
-{  
+{
   // Set initial gait selection number for gait toggling
   if (params_.gait_type.data == "tripod_gait")
   {
@@ -149,7 +149,7 @@ void StateController::init(void)
   walker_->init();
   poser_ = std::allocate_shared<PoseController>(Eigen::aligned_allocator<PoseController>(), model_, params_);
   poser_->init();
-  admittance_ = 
+  admittance_ =
     std::allocate_shared<AdmittanceController>(Eigen::aligned_allocator<AdmittanceController>(), model_, params_);
 
   robot_state_ = UNKNOWN;
@@ -185,7 +185,7 @@ void StateController::loop(void)
   {
     transitionRobotState();
   }
-  
+
   if (robot_state_ == RUNNING)
   {
     runningState();
@@ -379,7 +379,7 @@ void StateController::transitionRobotState(void)
 void StateController::runningState(void)
 {
   bool update_tip_position = true;
-  
+
   // Force Syropod to stop walking
   if (transition_state_flag_)
   {
@@ -411,7 +411,7 @@ void StateController::runningState(void)
     linear_velocity_input_ = linear_cruise_velocity_;
     angular_velocity_input_ = angular_cruise_velocity_;
   }
-  
+
   // Dynamically adjust parameters and change stance if required
   if (parameter_adjust_flag_)
   {
@@ -419,9 +419,9 @@ void StateController::runningState(void)
   }
 
   // Set true if already true or if walk state not STOPPED
-  update_tip_position = update_tip_position || walker_->getWalkState() != STOPPED; 
+  update_tip_position = update_tip_position || walker_->getWalkState() != STOPPED;
 
-  // Update tip positions unless Syropod is undergoing state transition, gait switch, parameter adjustment or 
+  // Update tip positions unless Syropod is undergoing state transition, gait switch, parameter adjustment or
   // leg state transition (which all only occur once the Syropod has stopped walking)
   if (update_tip_position)
   {
@@ -440,7 +440,7 @@ void StateController::runningState(void)
 
     // Pose controller takes current tip positions from walker and applies body posing
     poser_->updateStance();
-    
+
     // Model takes desired tip poses from pose controller and applies inverse/forwards kinematics
     model_->updateModel();
   }
@@ -462,11 +462,11 @@ void StateController::adjustParameter(void)
     walker_->generateLimits(new_step_cycle, &max_linear_speed_map, &max_angular_speed_map);
     walker_->setLinearSpeedLimitMap(max_linear_speed_map);
     walker_->setAngularSpeedLimitMap(max_angular_speed_map);
-    double max_linear_speed = 
+    double max_linear_speed =
       walker_->getLimit(linear_velocity_input_, angular_velocity_input_, max_linear_speed_map);
-    double max_angular_speed = 
+    double max_angular_speed =
       walker_->getLimit(linear_velocity_input_, angular_velocity_input_, max_angular_speed_map);
-    
+
     // Generate target velocities to achieve before changing step frequency
     Eigen::Vector2d target_linear_velocity;
     double target_angular_velocity;
@@ -483,9 +483,9 @@ void StateController::adjustParameter(void)
       target_linear_velocity = clamped(linear_velocity_input_, max_linear_speed);
       target_angular_velocity = clamped(angular_velocity_input_, -max_angular_speed, max_angular_speed);
     }
-    
+
     // Set new parameter once within new limits
-    if (walker_->getDesiredLinearVelocity()[0] <= target_linear_velocity[0] && 
+    if (walker_->getDesiredLinearVelocity()[0] <= target_linear_velocity[0] &&
         walker_->getDesiredLinearVelocity()[1] <= target_linear_velocity[1] &&
         abs(walker_->getDesiredAngularVelocity()) <= abs(target_angular_velocity))
     {
@@ -499,7 +499,7 @@ void StateController::adjustParameter(void)
                         "\n[SHC] Slowing to safe speed before setting new parameter '%s'\n", p->name.c_str());
     }
   }
-  
+
   if (set_new_parameter)
   {
     parameter_adjust_flag_ = false;
@@ -655,7 +655,7 @@ void StateController::executePlan(void)
   if (walker_->getWalkState() == STOPPED)
   {
     int progress;
-    
+
     // Publish request for step N of plan
     if (!target_configuration_acquired_ && !target_tip_pose_acquired_ && !target_body_pose_acquired_)
     {
@@ -709,7 +709,7 @@ void StateController::generateExternalTargetTransforms(void)
     std::shared_ptr<LegStepper> leg_stepper = leg->getLegStepper();
     std::shared_ptr<LegPoser> leg_poser = leg->getLegPoser();
     ExternalTarget external_target;
-    
+
     // External target transform
     external_target = leg_stepper->getExternalTarget();
     if (external_target.defined_)
@@ -719,17 +719,17 @@ void StateController::generateExternalTargetTransforms(void)
       try
       {
         geometry_msgs::TransformStamped target_transform;
-        target_transform = 
+        target_transform =
           transform_buffer_.lookupTransform(frame_id, past, "walk_plane", ros::Time(0), fixed_frame_id_);
         external_target.transform_ = Pose(target_transform.transform);
         leg_stepper->setExternalTarget(external_target);
       }
-      catch (tf2::TransformException &ex) 
+      catch (tf2::TransformException &ex)
       {
         ROS_DEBUG("\n[SHC] Unable to look up external target transform -- (%s)\n",ex.what());
       }
     }
-    
+
     // External default transform
     external_target = leg_stepper->getExternalDefault();
     if (external_target.defined_)
@@ -739,17 +739,17 @@ void StateController::generateExternalTargetTransforms(void)
       try
       {
         geometry_msgs::TransformStamped default_transform;
-        default_transform = 
+        default_transform =
           transform_buffer_.lookupTransform(frame_id, past, "walk_plane", ros::Time(0), fixed_frame_id_);
         external_target.transform_ = Pose(default_transform.transform);
         leg_stepper->setExternalDefault(external_target);
       }
-      catch (tf2::TransformException &ex) 
+      catch (tf2::TransformException &ex)
       {
         ROS_DEBUG("\n[SHC] Unable to look up external default transform -- (%s)\n",ex.what());
       }
     }
-    
+
     // External target transform for planner mode
     external_target = leg_poser->getExternalTarget();
     if (external_target.defined_)
@@ -759,12 +759,12 @@ void StateController::generateExternalTargetTransforms(void)
       try
       {
         geometry_msgs::TransformStamped target_transform;
-        target_transform = 
+        target_transform =
           transform_buffer_.lookupTransform("base_link", ros::Time(0), frame_id, past, fixed_frame_id_);
         external_target.transform_ = Pose(target_transform.transform);
         leg_poser->setExternalTarget(external_target);
       }
-      catch (tf2::TransformException &ex) 
+      catch (tf2::TransformException &ex)
       {
         ROS_DEBUG("\n[SHC] Unable to look up external target transform -- (%s)\n",ex.what());
       }
@@ -785,7 +785,7 @@ void StateController::publishDesiredJointState(void)
     {
       leg->generateDesiredJointStateMsg(&joint_state_msg);
     }
-    
+
     if (params_.individual_control_interface.data)
     {
       for (joint_it = leg->getJointContainer()->begin(); joint_it != leg->getJointContainer()->end(); ++joint_it)
@@ -822,19 +822,19 @@ void StateController::publishLegState(void)
     msg.walker_tip_pose.header.stamp = ros::Time::now();
     msg.walker_tip_pose.header.frame_id = "walk_plane";
     msg.walker_tip_pose.pose = leg_stepper->getCurrentTipPose().toPoseMessage();
-    
+
     msg.target_tip_pose.header.stamp = ros::Time::now();
     msg.target_tip_pose.header.frame_id = "walk_plane";
     msg.target_tip_pose.pose = leg_stepper->getTargetTipPose().toPoseMessage();
-    
+
     msg.poser_tip_pose.header.stamp = ros::Time::now();
     msg.poser_tip_pose.header.frame_id = "base_link";
     msg.poser_tip_pose.pose = leg_poser->getCurrentTipPose().toPoseMessage();
-    
+
     msg.model_tip_pose.header.stamp = ros::Time::now();
     msg.model_tip_pose.header.frame_id = "base_link";
     msg.model_tip_pose.pose = leg->getCurrentTipPose().toPoseMessage();
-    
+
     msg.actual_tip_pose.header.stamp = ros::Time::now();
     msg.actual_tip_pose.header.frame_id = "base_link";
     msg.actual_tip_pose.pose = leg->applyFK(false, true).toPoseMessage();
@@ -935,7 +935,7 @@ void StateController::publishWalkspace(void)
     {
       msg.data.push_back(static_cast<float>(walkspace_it->second));
     }
-    
+
     walkspace_publisher_.publish(msg);
   }
 }
@@ -965,17 +965,17 @@ void StateController::publishFrameTransforms(void)
   Pose odom_ideal_to_walk_plane = walker_->getOdometryIdeal();
   Pose walk_plane_to_base_link = model_->getCurrentPose();
   Pose odom_ideal_to_base_link = odom_ideal_to_walk_plane.addPose(walk_plane_to_base_link);
-  
+
   // Broadcast ideal odom tf, if odom tf from perception does not exist on tf tree
   try
   {
     fixed_frame_id_ = "odom";
     transform_buffer_.lookupTransform("base_link", "odom", ros::Time(0));
   }
-  catch (tf2::TransformException &ex) 
+  catch (tf2::TransformException &ex)
   {
     ROS_WARN_ONCE("\n[SHC] No odom transform exists in tf tree - using ideal odometry\n");
-    
+
     fixed_frame_id_ = "odom_ideal";
     geometry_msgs::TransformStamped odom_to_base_link;
     odom_to_base_link.header.stamp = ros::Time::now();
@@ -990,7 +990,7 @@ void StateController::publishFrameTransforms(void)
     odom_to_base_link.transform.rotation.z = odom_ideal_to_base_link.rotation_.z();
     transform_broadcaster_.sendTransform(odom_to_base_link);
   }
-  
+
   // Base Link frame to Walk Plane frame transform
   geometry_msgs::TransformStamped base_link_to_walk_plane;
   base_link_to_walk_plane.header.stamp = ros::Time::now();
@@ -1004,7 +1004,7 @@ void StateController::publishFrameTransforms(void)
   base_link_to_walk_plane.transform.rotation.y = (~walk_plane_to_base_link).rotation_.y();
   base_link_to_walk_plane.transform.rotation.z = (~walk_plane_to_base_link).rotation_.z();
   transform_broadcaster_.sendTransform(base_link_to_walk_plane);
-  
+
   // Base Link frame to Joint/Tip frames
   for (leg_it_ = model_->getLegContainer()->begin(); leg_it_ != model_->getLegContainer()->end(); ++leg_it_)
   {
@@ -1020,7 +1020,7 @@ void StateController::publishFrameTransforms(void)
       base_link_to_joint.transform.translation.x = joint_robot_frame.position_[0];
       base_link_to_joint.transform.translation.y = joint_robot_frame.position_[1];
       base_link_to_joint.transform.translation.z = joint_robot_frame.position_[2];
-      Eigen::Quaterniond rotation = 
+      Eigen::Quaterniond rotation =
         joint_robot_frame.rotation_ * Eigen::AngleAxisd(joint->desired_position_, Eigen::Vector3d::UnitZ());
       base_link_to_joint.transform.rotation.w = rotation.w();
       base_link_to_joint.transform.rotation.x = rotation.x();
@@ -1401,7 +1401,7 @@ void StateController::secondaryTipVelocityInputCallback(const geometry_msgs::Poi
 void StateController::primaryTipPoseInputCallback(const geometry_msgs::Pose &input)
 {
   primary_pose_input_.position_ = Eigen::Vector3d(input.position.x, input.position.y, input.position.z);
-  primary_pose_input_.rotation_ = 
+  primary_pose_input_.rotation_ =
     Eigen::Quaterniond(input.orientation.w, input.orientation.x, input.orientation.y, input.orientation.z);
 }
 
@@ -1410,7 +1410,7 @@ void StateController::primaryTipPoseInputCallback(const geometry_msgs::Pose &inp
 void StateController::secondaryTipPoseInputCallback(const geometry_msgs::Pose &input)
 {
   secondary_pose_input_.position_ = Eigen::Vector3d(input.position.x, input.position.y, input.position.z);
-  secondary_pose_input_.rotation_ = 
+  secondary_pose_input_.rotation_ =
     Eigen::Quaterniond(input.orientation.w, input.orientation.x, input.orientation.y, input.orientation.z);
 }
 
@@ -1563,7 +1563,6 @@ void StateController::imuCallback(const sensor_msgs::Imu &data)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 void StateController::jointStatesCallback(const sensor_msgs::JointState &joint_states)
 {
   bool get_effort_values = (joint_states.effort.size() != 0);
@@ -1575,18 +1574,22 @@ void StateController::jointStatesCallback(const sensor_msgs::JointState &joint_s
     std::string joint_name = joint_states.name[i];
     std::string leg_name = joint_name.substr(0, joint_name.find("_"));
     std::shared_ptr<Leg> leg = model_->getLegByIDName(leg_name);
-    ROS_ASSERT(leg != NULL);
-    std::shared_ptr<Joint> joint = leg->getJointByIDName(joint_name);
-    ROS_ASSERT(joint != NULL);
-    joint->current_position_ = joint_states.position[i] - joint->offset_;
-    if (get_velocity_values)
+    if (leg != NULL)
     {
-      joint->current_velocity_ = joint_states.velocity[i];
-    }
-    if (get_effort_values)
-    {
-      joint->current_effort_ = joint_states.effort[i];
-      joint->desired_effort_ = joint->current_effort_; // HACK
+      std::shared_ptr<Joint> joint = leg->getJointByIDName(joint_name);
+      if (joint != NULL)
+      {
+        joint->current_position_ = joint_states.position[i] - joint->offset_;
+        if (get_velocity_values)
+        {
+          joint->current_velocity_ = joint_states.velocity[i];
+        }
+        if (get_effort_values)
+        {
+          joint->current_effort_ = joint_states.effort[i];
+          joint->desired_effort_ = joint->current_effort_; // HACK
+        }
+      }
     }
   }
 
@@ -1616,7 +1619,7 @@ void StateController::tipStatesCallback(const syropod_highlevel_controller::TipS
 {
   bool get_wrench_values = tip_states.wrench.size() > 0;
   bool get_step_plane_values = tip_states.step_plane.size() > 0;
-  
+
   // Iterate through message and assign found contact proximity value to leg objects
   std::string error_string;
   for (uint i = 0; i < tip_states.name.size(); ++i)
@@ -1624,46 +1627,48 @@ void StateController::tipStatesCallback(const syropod_highlevel_controller::TipS
     std::string tip_name = tip_states.name[i];
     std::string leg_name = tip_name.substr(0, tip_name.find("_"));
     std::shared_ptr<Leg> leg = model_->getLegByIDName(leg_name);
-    ROS_ASSERT(leg != NULL);
-    std::shared_ptr<LegStepper> leg_stepper = leg->getLegStepper();
-    if (get_wrench_values)
+    if (leg != NULL)
     {
-      Eigen::Vector3d tip_force(tip_states.wrench[i].force.x,
-                                tip_states.wrench[i].force.y,
-                                tip_states.wrench[i].force.z);
-      Eigen::Vector3d tip_torque(tip_states.wrench[i].torque.x,
-                                 tip_states.wrench[i].torque.y,
-                                 tip_states.wrench[i].torque.z);
-      if (leg_stepper != NULL)
+      std::shared_ptr<LegStepper> leg_stepper = leg->getLegStepper();
+      if (get_wrench_values)
       {
-        leg_stepper->setTouchdownDetection(true);
+        Eigen::Vector3d tip_force(tip_states.wrench[i].force.x,
+                                  tip_states.wrench[i].force.y,
+                                  tip_states.wrench[i].force.z);
+        Eigen::Vector3d tip_torque(tip_states.wrench[i].torque.x,
+                                  tip_states.wrench[i].torque.y,
+                                  tip_states.wrench[i].torque.z);
+        if (leg_stepper != NULL)
+        {
+          leg_stepper->setTouchdownDetection(true);
+        }
+        leg->setTipForceMeasured(tip_force);
+        leg->setTipTorqueMeasured(tip_torque);
+        leg->touchdownDetection();
       }
-      leg->setTipForceMeasured(tip_force);
-      leg->setTipTorqueMeasured(tip_torque);
-      leg->touchdownDetection();
-    }
-    if (get_step_plane_values)
-    {
-      if (leg_stepper != NULL)
+      if (get_step_plane_values)
       {
-        leg_stepper->setTouchdownDetection(true);
-      }
-      if (tip_states.step_plane[i].z != UNASSIGNED_VALUE)
-      {
-        // From step plane representation calculate position and orientation of plane relative to tip frame
-        Eigen::Vector3d step_plane_position(tip_states.step_plane[i].z, 0.0, 0.0);
-        Eigen::Vector3d step_plane_normal(tip_states.step_plane[i].x, tip_states.step_plane[i].y, -1.0);
-        Eigen::Quaterniond step_plane_orientation = Eigen::Quaterniond::FromTwoVectors(Eigen::Vector3d(0, 0, 1.0),
-                                                                                       -step_plane_normal);
+        if (leg_stepper != NULL)
+        {
+          leg_stepper->setTouchdownDetection(true);
+        }
+        if (tip_states.step_plane[i].z != UNASSIGNED_VALUE)
+        {
+          // From step plane representation calculate position and orientation of plane relative to tip frame
+          Eigen::Vector3d step_plane_position(tip_states.step_plane[i].z, 0.0, 0.0);
+          Eigen::Vector3d step_plane_normal(tip_states.step_plane[i].x, tip_states.step_plane[i].y, -1.0);
+          Eigen::Quaterniond step_plane_orientation = Eigen::Quaterniond::FromTwoVectors(Eigen::Vector3d(0, 0, 1.0),
+                                                                                        -step_plane_normal);
 
-        // Transform into robot frame and store
-        Pose step_plane_pose = leg->getTip()->getPoseRobotFrame(Pose(step_plane_position, step_plane_orientation));
-        leg->setStepPlanePose(step_plane_pose); 
-      }
-      else
-      {
-        leg->setStepPlanePose(Pose::Undefined()); 
-        error_string += stringFormat("\nLost contact with tip range sensor/s of leg %s.\n", leg_name.c_str());
+          // Transform into robot frame and store
+          Pose step_plane_pose = leg->getTip()->getPoseRobotFrame(Pose(step_plane_position, step_plane_orientation));
+          leg->setStepPlanePose(step_plane_pose);
+        }
+        else
+        {
+          leg->setStepPlanePose(Pose::Undefined());
+          error_string += stringFormat("\nLost contact with tip range sensor/s of leg %s.\n", leg_name.c_str());
+        }
       }
     }
   }
@@ -1680,7 +1685,7 @@ void StateController::targetConfigurationCallback(const sensor_msgs::JointState 
   poser_->setTargetConfiguration(target_configuration);
   target_configuration_acquired_ = true;
 }
-  
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void StateController::targetBodyPoseCallback(const geometry_msgs::Pose &target_body_pose)
@@ -1714,7 +1719,7 @@ void StateController::targetTipPoseCallback(const syropod_highlevel_controller::
         {
           bool is_external_target = !msg.target.empty() && Pose(msg.target[i].pose) != Pose::Undefined();
           bool is_external_default = !msg.stance.empty() && Pose(msg.stance[i].pose) != Pose::Undefined();
-          
+
           // Create external target from message and send to walk/pose controller depending on walk state
           if (is_external_target)
           {
@@ -1736,7 +1741,7 @@ void StateController::targetTipPoseCallback(const syropod_highlevel_controller::
               target_tip_pose_acquired_ = true;
             }
           }
-          
+
           // Create external default from message and send to walk/ controller if walking
           if (is_external_default && walker_->getWalkState() != STOPPED)
           {


### PR DESCRIPTION
SHC will currently abort via ROS_ASSERT when it receives a joint states or tip states message with joints/tips it currently isn't controlling. As SHC does not always have control over every joint in the system, it should instead simply ignore the joints/tips it isn't controlling.