### PR TITLE
Removed robot name from IMU subscriber topic

### DIFF
--- a/src/state_controller.cpp
+++ b/src/state_controller.cpp
@@ -80,7 +80,7 @@ StateController::StateController(void)
   plan_step_request_publisher_ = n.advertise<std_msgs::Int8>("shc/plan_step_request", 1000);
 
   // Motor and other sensor topic subscriptions
-  imu_data_subscriber_ = n.subscribe(params_.syropod_type.data + "imu/data", 1, &StateController::imuCallback, this);
+  imu_data_subscriber_ = n.subscribe("imu/data", 1, &StateController::imuCallback, this);
   joint_state_subscriber_ = n.subscribe("joint_states", 100, &StateController::jointStatesCallback, this);
   tip_state_subscriber_ = n.subscribe("tip_states", 1, &StateController::tipStatesCallback, this);
 


### PR DESCRIPTION
Removed the robot name from subscriber topic for consistency since no other topic includes it. Either remap topic in launch file or launch in namespace if required.